### PR TITLE
Add CI testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: build
+
+# //TEMP we should probably filter a bit better here to not start the CI if
+# - documentation changes
+# - non impacting changes...
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "56 10 * * 1"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: build
+        run: |
+          cd docker
+          docker-compose up -d --build
+          docker-compose logs --tail="all"
+          docker ps
+      - name: test
+        run: |
+          # //TEMP the db needs to be up, there is probably a better way here
+          # (healthcheck?)
+          echo "Sleeping to let time for the DB to start"
+          sleep 10
+          docker exec -i $(docker ps --format "{{.Names}}" | grep web) python manage.py test

--- a/docker/.env
+++ b/docker/.env
@@ -4,6 +4,9 @@
 #
 # This is the default environment set up for docker-compose. Check
 # docker-compose.yml how these variables get passed to different containers.
+PYTHON_VERSION=3.9
+NGINX_VERSION=latest
+MARIADB_VERSION=10.6
 MARIADB_ROOT_PASSWORD=1234
 
 # For development purposes, the database data directory and configuration file

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,5 +1,6 @@
 # pull official base image
-FROM python:3.9
+ARG python_version=3.9
+FROM "python:$python_version"
 
 # set work directory
 WORKDIR /app/

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   db:
     build:
       context: ../
+      args:
+        mariadb_version: "${MARIADB_VERSION}"
       dockerfile: docker/mariadb/Dockerfile
     restart: always
     environment:
@@ -17,6 +19,8 @@ services:
   web:
     build:
       context: ../
+      args:
+        python_version: "${PYTHON_VERSION}"
       dockerfile: docker/app/Dockerfile
     restart: always
     environment:
@@ -39,7 +43,10 @@ services:
       - db
 
   nginx:
-    build: ./nginx
+    build:
+      context: ./nginx
+      args:
+        nginx_version: "${NGINX_VERSION}"
     restart: always
     volumes:
       - static_volume:/home/app/web/staticfiles

--- a/docker/mariadb/Dockerfile
+++ b/docker/mariadb/Dockerfile
@@ -1,4 +1,5 @@
-FROM mariadb:10.6
+ARG mariadb_version=10.6
+FROM "mariadb:$mariadb_version"
 
 RUN apt-get update && apt-get install -y python3 python3-pip libmariadb-dev
 RUN pip install --upgrade pip && \

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,3 +1,4 @@
-FROM nginx:latest
+ARG nginx_version=latest
+FROM "nginx:$nginx_version"
 RUN rm /etc/nginx/conf.d/default.conf
 COPY nginx.conf /etc/nginx/conf.d


### PR DESCRIPTION
This permits to test the stack in the CI.
It is also now possible to use different container versions:
PYTHON_VERSION=3.9
NGINX_VERSION=latest
MARIADB_VERSION=10.6

Not mandatory but this would permit more flexibility (even in the CI) to test different versions.