### PR TITLE
MDBF-423: Change default connection to database to use host different than dock…

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -29,6 +29,7 @@ DJANGO_DEBUG=True
 #
 # There will also be a test_{DJANGO_DB_NAME} database used for running tests.
 DJANGO_DB_NAME='feedback_plugin'
+DJANGO_DB_HOST='db'
 DJANGO_DB_USER_NAME='feedback'
 DJANGO_DB_USER_PASSWORD='A;p4rqgDt-Mf7L{z'
 

--- a/src/feedback_plugin/settings.py
+++ b/src/feedback_plugin/settings.py
@@ -20,13 +20,24 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
+SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = bool(os.environ['DJANGO_DEBUG'])
+DEBUG = bool(os.environ.get('DJANGO_DEBUG'))
+if DEBUG == None:
+    DEBUG = True
 
-ALLOWED_HOSTS = [os.environ['DJANGO_ALLOWED_HOSTS']]
+if os.environ.get('DJANGO_ALLOWED_HOSTS'):
+    ALLOWED_HOSTS = os.environ['DJANGO_ALLOWED_HOSTS'].split(',')
+# DB_HOST default value will be DNS on docker_default network for easier usage in docker-compose
+# DB_HOST empty means localhost, instead one should set the unix socket and/or other host
+DB_HOST = os.environ.get('DJANGO_DB_HOST')
+if DB_HOST == None:
+    DB_HOST = 'docker_db_1'
 
+LOG_LEVEL = os.environ.get('DJANGO_LOG_LEVEL')
+if LOG_LEVEL == None:
+    LOG_LEVEL = 'ERROR'
 
 # Application definition
 
@@ -72,14 +83,13 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'feedback_plugin.wsgi.application'
 
-
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
-        'NAME': os.environ['DJANGO_DB_NAME'],
+        'NAME': os.environ.get('DJANGO_DB_NAME'),
         'USER': os.environ['DJANGO_DB_USER_NAME'],
         'PASSWORD': os.environ['DJANGO_DB_USER_PASSWORD'],
-        'HOST': 'db',
+        'HOST': DB_HOST,
         'OPTIONS': {'charset': 'utf8',
                     'use_unicode': True},
         'TEST': {
@@ -150,12 +160,12 @@ LOGGING = {
     'loggers': {
         'django': {
             'handlers': ['console'],
-            'level': os.environ['DJANGO_LOG_LEVEL'],
+            'level': LOG_LEVEL,
             'propagate': False,
         },
         'views': {
             'handlers': ['console'],
-            'level': os.environ['DJANGO_LOG_LEVEL'],
+            'level': LOG_LEVEL,
             'propagate': False,
         },
     },


### PR DESCRIPTION
…er container

- After setting up the virtual environment for the project
  (note missing instruction how to work locally with venv in `Readme.md`) and
  after running the `makemigrations --dry-run` or starting the webserver,
  application is trying to connect with hardcoded hostname `db` used from Dockerfile
- This patch allows to add multiple hostname from environment variable separed
  by delimiter (I liked `,`) and since the create type in settings.py is `list` type
  it is free to use first value from a list.
- Proof
* No patch
```
$ export DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1
$ ./manage.py makemigrations --dry-run
/home/anel/mariadb/feedback-plugin-backend/env/lib/python3.8/site-packages/django/core/management/commands/makemigrations.py:105:
  RuntimeWarning: Got an error checking a consistent migration history performed for database connection 'default': (2005, "Unknown MySQL server host 'db' (-3)")
  warnings.warn(
Migrations for 'feedback_plugin':
  feedback_plugin/migrations/0002_alter_rawdata_upload_time.py
    - Alter field upload_time on rawdata
```
* With patch
```
$ ./manage.py makemigrations --dry-run
Migrations for 'feedback_plugin':
  feedback_plugin/migrations/0002_alter_rawdata_upload_time.py
    - Alter field upload_time on rawdata
```
- Also server gets started correctly
```
$ ./manage.py runserver
Performing system checks...

System check identified no issues (0 silenced).

You have 19 unapplied migration(s). Your project may not work properly until you apply the migrations for app(s): admin, auth, contenttypes, feedback_plugin, sessions.
Run 'python manage.py migrate' to apply them.
May 30, 2022 - 14:51:50
Django version 3.2.13, using settings 'feedback_plugin.settings'
Starting development server at http://127.0.0.1:8000/
Quit the server with CONTROL-C.
```