### PR TITLE
MDBF-424: fix missing grant and zoneinfo for tests

### DIFF
--- a/docker/mariadb/create_database_user.py
+++ b/docker/mariadb/create_database_user.py
@@ -38,7 +38,7 @@ sql = "grant all on `{}`.* to `{}`".format(
 cur.execute(sql)
 
 print('Granting rights for running Django tests...')
-sql = "grant create on *.* to `{}`".format(
+sql = "grant create, alter on *.* to `{}`".format(
          os.environ['DJANGO_DB_USER_NAME'])
 cur.execute(sql)
 

--- a/src/feedback_plugin/tests/test_process_raw_data.py
+++ b/src/feedback_plugin/tests/test_process_raw_data.py
@@ -1,6 +1,10 @@
 from datetime import datetime, timezone
 import os
-from zoneinfo import ZoneInfo
+import sys
+if sys.version_info.major == 3 and sys.version_info.minor >= 9:
+  from zoneinfo import ZoneInfo
+else:
+  from backports.zoneinfo import ZoneInfo
 
 from django.test import TestCase
 
@@ -75,8 +79,10 @@ class ProcessRawData(TestCase):
     test_data = load_test_data(os.path.join(
                                  os.path.dirname(os.path.realpath(__file__)),
                                  'test_data/'))
-
-    create_test_database(test_data)
+    try:
+      create_test_database(test_data)
+    except:
+      print("Problem with creating the test data.\nPossible missing grants for the user.")
 
     self.assertEqual(Upload.objects.all().count(), 8)
     self.assertEqual(Server.objects.all().count(), 5)


### PR DESCRIPTION
- Check the issue #5 for problem statment
- After the patch
```
$ ./manage.py test
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.......
----------------------------------------------------------------------
Ran 7 tests in 0.421s

OK
Destroying test database for alias 'default'...
```