### PR TITLE
Add CI testing for GitLab CI workflow

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,22 @@
+image: docker/compose:latest
+services:
+# If using private runners, privilegedMode must be enabled in order to use docker-in-docker
+  - docker:dind
+variables:
+# This variable must be set or else "docker exec ..." will not be able to find
+# a running docker container. See: https://hub.docker.com/_/docker under TLS.
+  DOCKER_TLS_CERTDIR: ""
+
+before_script:
+  - cd docker/
+  - chmod +x app/entrypoint.sh
+  - docker-compose up -d db
+  - docker-compose up -d --build
+
+stages:
+  - test
+
+python-test:
+  stage: test
+  script:
+    - docker exec -i docker_web_1 python manage.py test


### PR DESCRIPTION
## Description

This commit adds a .gitlab-ci.yml which creates a CI workflow for GitLab. The script will build the required docker containers and then execute the unit tests in src/feedback_plugin/tests. 

## How can this PR be tested?

Running the CI workflow on both public GitLab.com runners and private custom runners work as expected.

[GitLab.com runner example](https://gitlab.com/anson1014/feedback-plugin-backend/-/pipelines/561149875)

## Copyright

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.