### PR TITLE
MDBF-613: Create FEATUREs chart for Feedback Plugin

### DIFF
--- a/src/feedback_plugin/management/commands/_parallel_fact_extractor.py
+++ b/src/feedback_plugin/management/commands/_parallel_fact_extractor.py
@@ -1,18 +1,19 @@
 from concurrent.futures import ProcessPoolExecutor, wait
 from datetime import datetime, timedelta, timezone
-from typing import Callable
+from typing import Callable, TypeVar, Generic
 
 from django.core.management.base import BaseCommand
 
 from ...data_processing import extractors
 
 
-class ProcessPoolFactExtractor(BaseCommand):
+Extractor = TypeVar('Extractor', bound=extractors.DataExtractor)
+class ProcessPoolFactExtractor(Generic[Extractor], BaseCommand):
     def __init__(
             self,
             extract_cb: Callable[[datetime, datetime,
-                                  list[extractors.DataExtractor], bool], None],
-            extractors: list[extractors.DataExtractor],
+                                  list[Extractor], bool], None],
+            extractors: list[Extractor],
             *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._extract_cb = extract_cb

--- a/src/feedback_plugin/management/commands/compute_charts.py
+++ b/src/feedback_plugin/management/commands/compute_charts.py
@@ -19,6 +19,10 @@ CHARTS_MAP = {
             'callback': charts.compute_server_count_by_month,
             'title': 'Server Count by Month',
         },
+        'feature-count': {
+            'callback': charts.compute_feature_counts_by_month,
+            'title': 'Feature Count by Month',
+        },
         'version-breakdown': {
             'callback': charts.compute_version_breakdown_by_month,
             'title': 'Server Version Breakdown by Month',

--- a/src/feedback_plugin/tests/test_compute_charts_command.py
+++ b/src/feedback_plugin/tests/test_compute_charts_command.py
@@ -38,8 +38,8 @@ class ComputeChartsCommand(TestCase):
         first_upload = Upload.objects.all().order_by('upload_time')[:1][0]
         last_upload = Upload.objects.all().order_by('-upload_time')[:1][0]
 
-        self.assertEqual(Chart.objects.all().count(), 3)
-        self.assertEqual(ChartMetadata.objects.all().count(), 3)
+        self.assertEqual(Chart.objects.all().count(), 4)
+        self.assertEqual(ChartMetadata.objects.all().count(), 4)
 
         chart = Chart.objects.get(id='server-count')
         self.assertEqual(chart.title, 'Server Count by Month')
@@ -144,4 +144,34 @@ class ComputeChartsCommand(TestCase):
                                 'x': ['2022-1', '2022-2', '2022-3'],
                                 'y': [3, 4, 1],
                             }
+                         })
+
+    def test_compute_features_by_month(self):
+        create_test_database()
+
+        ComputeChartsCommand.call('--recreate', '--chart=feature-count')
+
+        self.assertEqual(Chart.objects.all().count(), 1)
+
+        chart = Chart.objects.get(id='feature-count')
+
+        self.assertEqual(chart.title, 'Feature Count by Month')
+        self.assertEqual(chart.values,
+                         {
+                            'check_constraint': {
+                                'x': ['2022-01', '2022-02'],
+                                'y': [2, 2],
+                            },
+                            'json': {
+                                'x': ['2022-01', '2022-02'],
+                                'y': [2, 2],
+                            },
+                            'subquery': {
+                                'x': ['2022-01', '2022-02', '2022-03'],
+                                'y': [2, 2, 1],
+                            },
+                            'timezone': {
+                                'x': ['2022-01', '2022-02', '2022-03'],
+                                'y': [2, 2, 1],
+                            },
                          })

--- a/src/feedback_plugin/tests/test_process_raw_data.py
+++ b/src/feedback_plugin/tests/test_process_raw_data.py
@@ -78,4 +78,4 @@ class TestLoadFixtures(TransactionTestCase):
     self.assertEqual(Upload.objects.all().count(), 8)
     self.assertEqual(Server.objects.all().count(), 5)
     self.assertEqual(ComputedServerFact.objects.all().count(), 36)
-    self.assertEqual(ComputedUploadFact.objects.all().count(), 24)
+    self.assertEqual(ComputedUploadFact.objects.all().count(), 31)


### PR DESCRIPTION
A new extractor and chart is added for a selected list of features. The extracted features are stored as JSON as specified in [MDBF-613](https://jira.mariadb.org/browse/MDBF-613) and the chart is stored like this (see `test_compute_features_by_month`):
```python
{
    'check_constraint': {
        'x': ['2022-01', '2022-02'],
        'y': [2, 2],
    },
    'json': {
        'x': ['2022-01', '2022-02'],
        'y': [2, 2],
    },
   ...
}
```

Currently the features collected are limited to the ones that have a non-zero value in the test data:
```python
COLLECTED_FEATURES = {'check_constraint', 'json', 'subquery', 'timezone'}
```

To make it possible to compute different upload facts for the same upload, the extractor code was reorganized a bit. See commit 8bd311a8b15d0c234ce2e07b7c8e535626f8dcd6.