### PR TITLE
Improve ARM extracting

### DIFF
--- a/src/feedback_plugin/data_processing/extractors.py
+++ b/src/feedback_plugin/data_processing/extractors.py
@@ -89,7 +89,7 @@ class ArchitectureExtractor(ServerFactExtractor):
             machine_architecture = 'x86'
         elif re.match('^armv[5-7]', machine):
             machine_architecture = 'ARM 32Bit'
-        elif re.match('^aarch64$', machine):
+        elif re.match('^(aarch64|arm64)$', machine):
             machine_architecture = 'ARM 64Bit'
         elif re.match('^hp_', machine):
             machine_architecture = 'HP Itanium'

--- a/src/feedback_plugin/data_processing/extractors.py
+++ b/src/feedback_plugin/data_processing/extractors.py
@@ -87,10 +87,8 @@ class ArchitectureExtractor(ServerFactExtractor):
         elif re.match('^[ix][3-6]*86$', machine):
             # This check must happen after x86_64
             machine_architecture = 'x86'
-        elif re.match('^armv[5-7]', machine):
-            machine_architecture = 'ARM 32Bit'
         elif re.match('^(aarch64|arm64)$', machine):
-            machine_architecture = 'ARM 64Bit'
+            machine_architecture = 'armv8'
         elif re.match('^hp_', machine):
             machine_architecture = 'HP Itanium'
         elif re.match('^alpha', machine):


### PR DESCRIPTION
arm64 is now handled the same way as aarch64. The grouping of 32-bit ARMs is removed to be able to analyze the data for individual generations and featuresets more easily.