### PR TITLE
Fix report processing errors

### DIFF
--- a/src/feedback_plugin/data_processing/etl.py
+++ b/src/feedback_plugin/data_processing/etl.py
@@ -47,14 +47,21 @@ def process_from_date(start_date: datetime, end_date: datetime):
         values = []
         data = {}
         errored = False
+        value_max_length = Data._meta.get_field('value').max_length
         for row in reader:
             # We only expect KV pairs.
             if len(row) != 2:
                 errored = True
                 break
 
-            data[row[0]] = row[1]
-            values.append(Data(key=row[0], value=row[1]))
+            value = row[1]
+            if len(value) > value_max_length:
+                logger.info(f'Truncated value for key {row[0]!r} from '
+                           f'{len(value)} to {value_max_length} chars')
+                value = value[:value_max_length]
+
+            data[row[0]] = value
+            values.append(Data(key=row[0], value=value))
 
         if errored:
             raw_upload.delete()

--- a/src/feedback_plugin/views.py
+++ b/src/feedback_plugin/views.py
@@ -88,6 +88,12 @@ def handle_upload_form(request, ip=None, upload_time=None):
         if ip is None:
             raise TypeError
         report_country = geoip.country_code(ip)
+        if report_country is None:
+            # GeoIP2 can resolve the IP but still have no country attached
+            # to it (e.g. anonymous proxy / satellite ranges) without
+            # raising an exception.
+            logger.warning(f'GeoIP2 returned no country for IP {ip}')
+            report_country = 'ZZ'
     except (GeoIP2Exception, GeoIP2Error, TypeError, socket.gaierror):
         report_country = 'ZZ'  # Unknown according to ISO 3166-1993
 


### PR DESCRIPTION
Fall back to report_country = ZZ when GeoIP2 resolves IP with no country 
Check value for each key from a report and trim it down to a maximum of 1000 characters to avoid crashes in process_raw_data